### PR TITLE
Temporarily disable a spec because of expired cert

### DIFF
--- a/spec/components/ssl_certificates_spec.rb
+++ b/spec/components/ssl_certificates_spec.rb
@@ -19,7 +19,8 @@ describe SSLCertificates do
       expect(described_class_instance.results).to eq([['taylorjthurlow.com', DateTime.parse('Jul 12 08:17:27 2018 GMT')]])
     end
 
-    it 'prints the list of statuses' do
+    # FIXME: expired SSL certificate
+    xit 'prints the list of statuses' do
       results = described_class_instance.to_s.delete(' ') # handle variable whitespace
       expect(results).to include 'taylorjthurlow.com' + 'validuntil'.green
     end


### PR DESCRIPTION
I believe that `taylorjthurlow.com` is now expired, so tests would fail. It would be wise to disable them until we can do something with it.