### PR TITLE
Add fail2ban component

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,6 +31,9 @@ RSpec/MultipleExpectations:
 RSpec/SubjectStub:
   Enabled: false
 
+RSpec/FilePath:
+  Enabled: false
+
 Style/BlockDelimiters:
   Exclude:
     - 'spec/**/*'

--- a/lib/panda_motd/components/fail_2_ban.rb
+++ b/lib/panda_motd/components/fail_2_ban.rb
@@ -1,0 +1,45 @@
+require 'pry'
+class Fail2Ban < Component
+  def initialize(motd)
+    super(motd, 'fail_2_ban')
+  end
+
+  def process
+    @results = {
+      jails: {}
+    }
+
+    @config['jails'].each do |jail|
+      status = jail_status(jail)
+      @results[:jails][jail] = {
+        total: status[:total],
+        current: status[:current]
+      }
+    end
+  end
+
+  def to_s
+    result = "Fail2Ban:\n"
+    @results[:jails].each do |name, stats|
+      result += "  #{name}:\n"
+      result += "    Total bans:   #{stats[:total]}\n"
+      result += "    Current bans: #{stats[:current]}\n"
+    end
+
+    result.gsub(/\s$/, '')
+  end
+
+  private
+
+  def jail_status(jail)
+    cmd_result = `fail2ban-client status #{jail}`
+    if cmd_result =~ /Sorry but the jail '#{jail}' does not exist/
+      @errors << ComponentError.new(self, "Invalid jail name '#{jail}'.")
+    else
+      total = cmd_result.match(/Total banned:\s+([0-9]+)/)[1].to_i
+      current = cmd_result.match(/Currently banned:\s+([0-9]+)/)[1].to_i
+    end
+
+    { total: total, current: current }
+  end
+end

--- a/lib/panda_motd/config.rb
+++ b/lib/panda_motd/config.rb
@@ -31,7 +31,8 @@ class Config
       uptime: Uptime,
       ssl_certificates: SSLCertificates,
       filesystems: Filesystems,
-      last_login: LastLogin
+      last_login: LastLogin,
+      fail_2_ban: Fail2Ban
     }
   end
 

--- a/lib/panda_motd/default_config.yaml
+++ b/lib/panda_motd/default_config.yaml
@@ -96,6 +96,22 @@ components:
   #     /dev/sdc1: Data
 
   #####
+  # Fail2Ban
+  #   Displays fail2ban jail statistics.
+  #
+  # Settings
+  #   jails: A list of fail2ban jails to obtain statistics from. The name of the
+  #     jail is the same name used in the `fail2ban-client status jailname`. You
+  #     will get the total banned and currently banned numbers for each jail.
+  #####
+
+  # fail_2_ban:
+  #   enabled: true
+  #   jails:
+  #     - sshd
+  #     - anotherjail
+
+  #####
   # Last Login
   #   Displays previous login information for users.
   #

--- a/spec/components/fail_2_ban_spec.rb
+++ b/spec/components/fail_2_ban_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+require 'pry'
+
+describe Fail2Ban do
+  context 'with normal config' do
+    subject(:component) { create(:fail_2_ban) }
+
+    it 'gets statistics' do
+      stub_system_call(component)
+
+      component.process
+
+      expect(component.results[:jails]).to eq(
+        'sshd' => { total: 871, current: 0 }
+      )
+    end
+
+    it 'prints the results' do
+      stub_system_call(component)
+
+      component.process
+      results = component.to_s
+
+      expect(results).to include 'Fail2Ban:'
+      expect(results).to include 'Total bans:   871'
+      expect(results).to include 'Current bans: 0'
+    end
+  end
+
+  context 'with config containing an invalid jail name' do
+    subject(:component) {
+      create(:fail_2_ban, settings: { 'jails' => ['asdf'] })
+    }
+
+    it 'adds an error to the component' do
+      stub_system_call(
+        component,
+        returns: "Sorry but the jail 'asdf' does not exist"
+      )
+
+      component.process
+
+      expect(component.errors.count).to eq 1
+      expect(component.errors.first.message).to eq "Invalid jail name 'asdf'."
+    end
+  end
+end

--- a/spec/fixtures/components/fail_2_ban/output.txt
+++ b/spec/fixtures/components/fail_2_ban/output.txt
@@ -1,0 +1,9 @@
+Status for the jail: sshd
+|- Filter
+|  |- Currently failed: 0
+|  |- Total failed:     9166
+|  `- File list:        /var/log/auth.log
+`- Actions
+   |- Currently banned: 0
+   |- Total banned:     871
+   `- Banned IP list:`

--- a/spec/fixtures/configs/fail_2_ban.yaml
+++ b/spec/fixtures/configs/fail_2_ban.yaml
@@ -1,0 +1,5 @@
+components:
+  fail_2_ban:
+    enabled: true
+    jails:
+      - sshd


### PR DESCRIPTION
Per #24 I've implemented a fail2ban component. The first thought in the issue was to print ban statistics based on the logs themselves, but this means that we're unable to differentiate bans based on their jail name. I figured this was important so as it is, the component takes jail names and will print a total banned count and a currently banned count for each jail.

From the [mentioned article](https://www.the-art-of-web.com/system/fail2ban-log/), there is a section on getting statistics for each day - which is cool - so it might be worth adding another section to the component which will print global ban statistics for the last N number of days, even if it's not on a per-jail basis. More investigating needed.

Closes #24.